### PR TITLE
ビルドエラーの修正とLint警告の解消

### DIFF
--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -163,7 +163,7 @@ export function Results({ data, targetAmount, retirementAge }: ResultsProps) {
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="age" label={{ value: '年齢', position: 'insideBottomRight', offset: -5 }} unit="歳" />
                 <YAxis label={{ value: '万円', angle: -90, position: 'insideLeft' }} />
-                <Tooltip formatter={(value: any) => typeof value === 'number' ? `${value.toLocaleString()} 万円` : value} />
+                <Tooltip formatter={(value: number | string | Array<number | string> | undefined) => typeof value === 'number' ? `${value.toLocaleString()} 万円` : value} />
                 <Legend />
                 <Area type="monotone" dataKey="yearEndBalance" name="総資産" stroke="#8884d8" fill="#8884d8" />
                 <Area type="monotone" dataKey="target" name="目標額" stroke="#ff7f0e" fill="none" strokeDasharray="5 5" />
@@ -182,7 +182,7 @@ export function Results({ data, targetAmount, retirementAge }: ResultsProps) {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="age" label={{ value: '年齢', position: 'insideBottomRight', offset: -5 }} unit="歳" />
                     <YAxis label={{ value: '万円', angle: -90, position: 'insideLeft' }} />
-                    <Tooltip formatter={(value: any) => typeof value === 'number' ? `${value.toLocaleString()} 万円` : value} />
+                    <Tooltip formatter={(value: number | string | Array<number | string> | undefined) => typeof value === 'number' ? `${value.toLocaleString()} 万円` : value} />
                     <Legend />
                     <Bar dataKey="incomeBreakdown.salary" name="給与収入" stackId="a" fill="#3b82f6" />
                     <Bar dataKey="incomeBreakdown.bonus" name="退職金" stackId="a" fill="#0ea5e9" />
@@ -203,7 +203,7 @@ export function Results({ data, targetAmount, retirementAge }: ResultsProps) {
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="age" label={{ value: '年齢', position: 'insideBottomRight', offset: -5 }} unit="歳" />
                     <YAxis label={{ value: '万円', angle: -90, position: 'insideLeft' }} />
-                    <Tooltip formatter={(value: any) => typeof value === 'number' ? `${value.toLocaleString()} 万円` : value} />
+                    <Tooltip formatter={(value: number | string | Array<number | string> | undefined) => typeof value === 'number' ? `${value.toLocaleString()} 万円` : value} />
                     <Legend />
                     <Bar dataKey="expenseBreakdown.living" name="基本生活費" stackId="a" fill="#f97316" />
                     <Bar dataKey="expenseBreakdown.housing" name="住居費" stackId="a" fill="#ef4444" />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useId } from 'react';
+import { useState, useId } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import type { SimulationInput, HousingPlan, PostRetirementJob, Child, OneTimeEvent } from '../logic/simulation';
 import { EDUCATION_PATTERNS } from '../logic/simulation';
@@ -354,11 +354,10 @@ function NumberInput({ label, value, onChange, step = 1, className = "", tooltip
   const [inputValue, setInputValue] = useState(value.toString());
   const [isFocused, setIsFocused] = useState(false);
 
-  useEffect(() => {
-    if (!isFocused) {
-      setInputValue(value.toString());
-    }
-  }, [value, isFocused]);
+  // Sync state with props when not focused
+  if (!isFocused && inputValue !== value.toString()) {
+    setInputValue(value.toString());
+  }
 
   const handleBlur = () => {
     setIsFocused(false);


### PR DESCRIPTION
`npm run build` が断続的に失敗する問題、およびLintエラーに対処しました。

変更点:
- `src/components/Results.tsx`: Rechartsの `Tooltip` コンポーネントにおける `any` 型の使用を廃止し、厳密な型定義に置き換えました。
- `src/components/Sidebar.tsx`: `useEffect` 内での `setState` 呼び出しを廃止し、レンダリングサイクル内での条件付き更新とフォーカス制御による同期ロジックに変更しました。これにより、Reactの警告を解消しつつ、入力フィールドの挙動（Blur時のリセット等）を維持しました。

---
*PR created automatically by Jules for task [167581364350836084](https://jules.google.com/task/167581364350836084) started by @horoama*