### PR TITLE
実測値（実質値）と名目値の表示切り替え機能の実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
     oneTimeEvents: []
   });
 
-  const simulationData = useMemo(() => {
+  const simulationResult = useMemo(() => {
     return calculateSimulation(input);
   }, [input]);
 
@@ -80,9 +80,10 @@ function App() {
       {/* Results (Graph) */}
       <div className={`flex-1 ${activeTab === 'result' ? 'block' : 'hidden lg:block'}`}>
         <Results
-          data={simulationData}
+          real={simulationResult.real}
+          nominal={simulationResult.nominal}
+          input={input}
           targetAmount={targetAmount}
-          retirementAge={input.retirementAge}
         />
       </div>
     </div>


### PR DESCRIPTION
実測値（実質値）と名目値の表示切り替え機能を実装しました。

主な変更点:
- `src/logic/simulation.ts`: シミュレーション計算ロジックを修正し、実質値と名目値の両方のデータセットを計算して返すように変更。
- `src/components/Results.tsx`: 結果画面に切り替えスイッチを追加し、グラフ・表・指標・CSVダウンロードが選択されたモード（実質値/名目値）に基づいて表示されるように対応。
- 名目値モードでは、目標金額のラインもインフレ率を考慮して上昇するように調整。
- ツールチップの文言を動的に変更し、表示中の値がどちらであるかを明示。
- ユニットテストを追加し、名目値の計算が正しいこと（昇給率のみが適用され、インフレによる減少がないこと等）を検証。

---
*PR created automatically by Jules for task [7004094348705775835](https://jules.google.com/task/7004094348705775835) started by @horoama*