### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Archive production artifacts
+        run: |
+          REPO_NAME="${{ github.event.repository.name }}"
+          TAG_NAME="${{ github.ref_name }}"
+          ARCHIVE_NAME="${REPO_NAME}-${TAG_NAME}.zip"
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
+
+          echo "Archiving dist folder into ${ARCHIVE_NAME}..."
+          zip -r "${ARCHIVE_NAME}" dist/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ARCHIVE_NAME }}
+          generate_release_notes: true


### PR DESCRIPTION
タグプッシュ時に自動的にビルドし、成果物（distフォルダのzip圧縮）をGitHub Releasesにアップロードするワークフローを追加しました。Node.js 22を使用します。

---
*PR created automatically by Jules for task [5933399077837966755](https://jules.google.com/task/5933399077837966755) started by @horoama*