### PR TITLE
Enable manual release to production and automatic staging deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs:
   build-and-release:
@@ -28,6 +29,7 @@ jobs:
         run: npm run build
 
       - name: Archive production artifacts
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           REPO_NAME="${{ github.event.repository.name }}"
           TAG_NAME="${{ github.ref_name }}"
@@ -38,6 +40,7 @@ jobs:
           zip -r "${ARCHIVE_NAME}" dist/
 
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.ARCHIVE_NAME }}

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build -- --mode staging
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,18 +6,29 @@ import viteCompression from 'vite-plugin-compression'
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const isDev = mode === 'development'
+  const isStaging = mode === 'staging'
+
+  // Set base path based on mode
+  // Development: /
+  // Staging: /LifePath/ (for GitHub Pages on this repo)
+  // Production: /lifeplan/ (for deployment to horoama.github.io/lifeplan)
+  let base = '/lifeplan/'
+  if (isDev) {
+    base = '/'
+  } else if (isStaging) {
+    base = '/LifePath/'
+  }
 
   return {
-    // Set base path to /lifeplan/ for production, / for development
-    base: isDev ? '/' : '/lifeplan/',
+    base,
     plugins: [
       react(),
       tailwindcss(),
-      // Only compress in production
+      // Only compress in production/staging (not dev)
       !isDev && viteCompression(),
     ],
     esbuild: {
-      // Only drop console/debugger in production
+      // Only drop console/debugger in production/staging
       drop: isDev ? [] : ['console', 'debugger'],
     },
     build: {


### PR DESCRIPTION
- **STG環境の構築**: `.github/workflows/stg-deploy.yml` を追加し、`main` ブランチへのプッシュ時に `staging` モードでビルドし、このリポジトリの GitHub Pages (`/LifePath/`) にデプロイするようにしました。
- **手動リリースの有効化**: `.github/workflows/release.yml` に `workflow_dispatch` を追加し、手動で本番環境 (`horoama.github.io/lifeplan`) へのデプロイを実行できるようにしました。手動実行時は GitHub Release の作成（zip作成含む）はスキップされます。
- **Vite設定の更新**: `vite.config.ts` を修正し、`staging` モード時は `base` パスを `/LifePath/` に設定するようにしました。

**注意:** STG環境へのデプロイを機能させるため、このリポジトリの Settings -> Pages -> Build and deployment -> Source を **"GitHub Actions"** に変更してください。

---
*PR created automatically by Jules for task [16332254297627925138](https://jules.google.com/task/16332254297627925138) started by @horoama*