### PR TITLE
Add simulation result summary feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,6 +87,7 @@ function App() {
           data={simulationData}
           targetAmount={targetAmount}
           retirementAge={input.retirementAge}
+          input={input}
         />
       </div>
     </div>

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,20 +1,23 @@
-import { useMemo, useRef, useCallback } from 'react';
+import { useMemo, useRef, useCallback, useState } from 'react';
 import { toPng } from 'html-to-image';
-import { Camera } from 'lucide-react';
+import { Camera, FileText, Download } from 'lucide-react';
 import {
   Area, AreaChart, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
-import { Download } from 'lucide-react';
 import { Tooltip as InfoTooltip } from './Tooltip';
-import type { SimulationYearResult } from '../logic/simulation';
+import { SummaryModal } from './SummaryModal';
+import { generateSimulationSummary } from '../logic/summaryGenerator';
+import type { SimulationYearResult, SimulationInput } from '../logic/simulation';
 
 type ResultsProps = {
   data: SimulationYearResult[];
   targetAmount: number;
   retirementAge: number;
+  input: SimulationInput;
 };
 
-export function Results({ data, targetAmount, retirementAge }: ResultsProps) {
+export function Results({ data, targetAmount, retirementAge, input }: ResultsProps) {
+  const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const tableContainerRef = useRef<HTMLDivElement>(null);
 
@@ -44,6 +47,10 @@ export function Results({ data, targetAmount, retirementAge }: ResultsProps) {
       target: targetAmount
     }));
   }, [data, targetAmount]);
+
+  const summaryText = useMemo(() => {
+    return generateSimulationSummary(input, data, targetAmount);
+  }, [input, data, targetAmount]);
 
   const handleSaveImage = useCallback(() => {
     if (ref.current === null || tableContainerRef.current === null) {
@@ -148,15 +155,30 @@ export function Results({ data, targetAmount, retirementAge }: ResultsProps) {
 
   return (
     <div className="flex-1 p-8 overflow-y-auto bg-gray-100" ref={ref}>
+      <SummaryModal
+        isOpen={isSummaryModalOpen}
+        onClose={() => setIsSummaryModalOpen(false)}
+        summaryText={summaryText}
+      />
+
       <div className="flex justify-between items-center mb-8">
         <h1 className="text-3xl font-bold text-gray-800">ライフプラン・シミュレーション結果</h1>
-        <button
-            onClick={handleSaveImage}
-            className="no-capture flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded shadow transition-colors cursor-pointer"
-        >
-            <Camera size={20} />
-            <span>画像で保存</span>
-        </button>
+        <div className="flex gap-2">
+            <button
+                onClick={() => setIsSummaryModalOpen(true)}
+                className="no-capture flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded shadow transition-colors cursor-pointer"
+            >
+                <FileText size={20} />
+                <span>結果をまとめる</span>
+            </button>
+            <button
+                onClick={handleSaveImage}
+                className="no-capture flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded shadow transition-colors cursor-pointer"
+            >
+                <Camera size={20} />
+                <span>画像で保存</span>
+            </button>
+        </div>
       </div>
 
       {/* Metrics */}

--- a/src/components/SummaryModal.tsx
+++ b/src/components/SummaryModal.tsx
@@ -1,0 +1,70 @@
+import { Copy, X, Check } from 'lucide-react';
+import { useState } from 'react';
+
+type SummaryModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  summaryText: string;
+};
+
+export function SummaryModal({ isOpen, onClose, summaryText }: SummaryModalProps) {
+  const [copied, setCopied] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(summaryText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm transition-opacity">
+      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full overflow-hidden animate-fade-in-up flex flex-col max-h-[90vh]">
+        {/* Header */}
+        <div className="bg-brand p-4 flex justify-between items-center text-white shrink-0">
+          <h2 className="text-lg font-bold flex items-center gap-2">
+            シミュレーション結果のまとめ
+          </h2>
+          <button onClick={onClose} className="text-white/80 hover:text-white transition-colors cursor-pointer">
+            <X size={24} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 flex-1 overflow-hidden flex flex-col min-h-0">
+          <p className="text-sm text-gray-600 mb-2">
+            以下のテキストは、現在の入力内容とシミュレーション結果をまとめたものです。
+            コピーしてメモや相談用にお使いください。
+          </p>
+          <div className="flex-1 border rounded-md bg-gray-50 overflow-auto p-4 font-mono text-sm leading-relaxed whitespace-pre-wrap text-gray-800">
+            {summaryText}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 bg-gray-50 flex justify-end gap-3 border-t border-gray-100 shrink-0">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-200 rounded transition-colors cursor-pointer"
+          >
+            閉じる
+          </button>
+          <button
+            onClick={handleCopy}
+            className={`flex items-center gap-2 px-6 py-2 rounded font-bold text-white transition-all shadow cursor-pointer ${
+              copied ? 'bg-green-600 hover:bg-green-700' : 'bg-brand hover:bg-blue-700'
+            }`}
+          >
+            {copied ? <Check size={18} /> : <Copy size={18} />}
+            {copied ? 'コピーしました' : 'テキストをコピー'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/logic/summaryGenerator.test.ts
+++ b/src/logic/summaryGenerator.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { generateSimulationSummary } from './summaryGenerator';
+import type { SimulationInput, SimulationYearResult } from './simulation';
+
+describe('generateSimulationSummary', () => {
+  const baseInput: SimulationInput = {
+    currentAge: 30,
+    currentAssets: 500,
+    interestRatePct: 3.0,
+    inflationRatePct: 1.0,
+    incomeIncreaseRatePct: 2.0,
+    deathAge: 90,
+    monthlyIncome: 30,
+    annualBonus: 100,
+    retirementAge: 65,
+    retirementBonus: 1000,
+    postRetirementJobs: [],
+    monthlyLivingCost: 15,
+    housingPlans: [
+      { cost: 10, duration: 'infinite' }
+    ],
+    children: [],
+    oneTimeEvents: []
+  };
+
+  const mockData: SimulationYearResult[] = [
+      {
+          age: 30, yearEndBalance: 600, yearsPassed: 0, event: '', monthlyHousingCost: 10,
+          annualIncome: 460, annualExpenses: 300, annualSavings: 160, yearEndBalanceReal: 600,
+          investmentIncome: 0, totalPrincipal: 500, totalInvestmentIncome: 0,
+          incomeBreakdown: { salary: 460, bonus: 0, pension: 0, oneTime: 0 },
+          expenseBreakdown: { living: 180, housing: 120, education: 0, oneTime: 0 }
+      },
+      {
+          age: 40, yearEndBalance: 2000, yearsPassed: 10, event: '', monthlyHousingCost: 10,
+          annualIncome: 500, annualExpenses: 350, annualSavings: 150, yearEndBalanceReal: 1800,
+          investmentIncome: 50, totalPrincipal: 1500, totalInvestmentIncome: 500,
+          incomeBreakdown: { salary: 500, bonus: 0, pension: 0, oneTime: 0 },
+          expenseBreakdown: { living: 200, housing: 120, education: 0, oneTime: 0 }
+      },
+      {
+          age: 50, yearEndBalance: 4000, yearsPassed: 20, event: '', monthlyHousingCost: 10,
+          annualIncome: 550, annualExpenses: 400, annualSavings: 150, yearEndBalanceReal: 3200,
+          investmentIncome: 100, totalPrincipal: 3000, totalInvestmentIncome: 1000,
+          incomeBreakdown: { salary: 550, bonus: 0, pension: 0, oneTime: 0 },
+          expenseBreakdown: { living: 250, housing: 120, education: 0, oneTime: 0 }
+      },
+      {
+          age: 65, yearEndBalance: 6000, yearsPassed: 35, event: 'Retirement', monthlyHousingCost: 10,
+          annualIncome: 1500, annualExpenses: 450, annualSavings: 1050, yearEndBalanceReal: 4000,
+          investmentIncome: 200, totalPrincipal: 4500, totalInvestmentIncome: 1500,
+          incomeBreakdown: { salary: 500, bonus: 1000, pension: 0, oneTime: 0 },
+          expenseBreakdown: { living: 300, housing: 120, education: 0, oneTime: 0 }
+      },
+      {
+          age: 80, yearEndBalance: 3000, yearsPassed: 50, event: '', monthlyHousingCost: 10,
+          annualIncome: 200, annualExpenses: 500, annualSavings: -300, yearEndBalanceReal: 1500,
+          investmentIncome: 100, totalPrincipal: 3000, totalInvestmentIncome: 2000,
+          incomeBreakdown: { salary: 0, bonus: 0, pension: 200, oneTime: 0 },
+          expenseBreakdown: { living: 350, housing: 120, education: 0, oneTime: 0 }
+      },
+      {
+          age: 90, yearEndBalance: -500, yearsPassed: 60, event: '', monthlyHousingCost: 10,
+          annualIncome: 200, annualExpenses: 550, annualSavings: -350, yearEndBalanceReal: -300,
+          investmentIncome: 0, totalPrincipal: 2000, totalInvestmentIncome: 2000,
+          incomeBreakdown: { salary: 0, bonus: 0, pension: 200, oneTime: 0 },
+          expenseBreakdown: { living: 400, housing: 120, education: 0, oneTime: 0 }
+      }
+  ];
+
+  it('should generate basic summary', () => {
+    const summary = generateSimulationSummary(baseInput, mockData, 3000);
+
+    expect(summary).toContain('現在の年齢: 30歳');
+    expect(summary).toContain('現在の資産: 500万円');
+    expect(summary).toContain('目標資産(3,000万円): 50歳で到達'); // Based on mockData
+    expect(summary).toContain('資産ピーク: 65歳 (6,000万円)');
+    expect(summary).toContain('資産枯渇: 90歳でマイナスに転落');
+  });
+
+  it('should handle target not reached', () => {
+    const summary = generateSimulationSummary(baseInput, mockData, 10000);
+    expect(summary).toContain('目標資産(10,000万円): 到達せず');
+  });
+
+  it('should include children info if present', () => {
+      const childInput: SimulationInput = {
+          ...baseInput,
+          children: [
+              { birthYearOffset: -5, educationPattern: '全公立', monthlyChildcareCost: 1 },
+              { birthYearOffset: 2, educationPattern: '全私立', monthlyChildcareCost: 2 }
+          ]
+      };
+      const summary = generateSimulationSummary(childInput, mockData, 3000);
+      expect(summary).toContain('子供: 2人');
+      expect(summary).toContain('第1子 (5歳): 全公立');
+      expect(summary).toContain('第2子 (2年後誕生予定): 全私立');
+  });
+});

--- a/src/logic/summaryGenerator.ts
+++ b/src/logic/summaryGenerator.ts
@@ -1,0 +1,101 @@
+import type { SimulationInput, SimulationYearResult } from './simulation';
+
+export function generateSimulationSummary(
+  input: SimulationInput,
+  data: SimulationYearResult[],
+  targetAmount: number
+): string {
+  const lines: string[] = [];
+
+  // --- 1. Input Summary ---
+  lines.push('【シミュレーション条件】');
+  lines.push(`現在の年齢: ${input.currentAge}歳`);
+  lines.push(`シミュレーション終了年齢: ${input.deathAge}歳`);
+  lines.push(`現在の資産: ${input.currentAssets.toLocaleString()}万円`);
+
+  lines.push('');
+  lines.push('■ 収入・資産運用');
+  lines.push(`メインの就労収入: 月収${input.monthlyIncome.toLocaleString()}万円 / ボーナス年${input.annualBonus.toLocaleString()}万円`);
+  if (input.incomeIncreaseRatePct > 0) {
+    lines.push(`収入上昇率: 年${input.incomeIncreaseRatePct}%`);
+  }
+  lines.push(`定年退職: ${input.retirementAge}歳 (退職金 ${input.retirementBonus.toLocaleString()}万円)`);
+  if (input.postRetirementJobs.length > 0) {
+    lines.push('退職後の働き方: あり');
+  }
+  lines.push(`想定利回り: 年${input.interestRatePct}%`);
+
+  lines.push('');
+  lines.push('■ 支出・家族');
+  lines.push(`基本生活費: 月${input.monthlyLivingCost.toLocaleString()}万円`);
+  if (input.inflationRatePct > 0) {
+    lines.push(`インフレ率: 年${input.inflationRatePct}%`);
+  }
+
+  // Housing
+  const currentHousing = input.housingPlans[0];
+  if (currentHousing) {
+     lines.push(`現在の住居費: 月${currentHousing.cost.toLocaleString()}万円 (${formatDuration(currentHousing.duration)})`);
+     if (input.housingPlans.length > 1) {
+        lines.push(`※ 以降、${input.housingPlans.length - 1}回の住居変更プランあり`);
+     }
+  }
+
+  // Children
+  if (input.children.length > 0) {
+      lines.push(`子供: ${input.children.length}人`);
+      input.children.forEach((child, idx) => {
+          const age = child.birthYearOffset < 0 ? -child.birthYearOffset : 0; // rough current age or 0 if unborn
+          const status = child.birthYearOffset > 0 ? `${child.birthYearOffset}年後誕生予定` : `${age}歳`;
+          lines.push(`  - 第${idx+1}子 (${status}): ${child.educationPattern}`);
+      });
+  } else {
+      lines.push('子供: なし');
+  }
+
+  lines.push('--------------------------------------------------');
+
+  // --- 2. Result Summary ---
+  lines.push('【シミュレーション結果】');
+
+  // Target Reach
+  const reachedRow = data.find(row => row.yearEndBalance >= targetAmount);
+  if (reachedRow) {
+      lines.push(`目標資産(${targetAmount.toLocaleString()}万円): ${reachedRow.age}歳で到達`);
+  } else {
+      lines.push(`目標資産(${targetAmount.toLocaleString()}万円): 到達せず`);
+  }
+
+  // Peak Assets
+  let peakBalance = -Infinity;
+  let peakAge = input.currentAge;
+  data.forEach(d => {
+      if (d.yearEndBalance > peakBalance) {
+          peakBalance = d.yearEndBalance;
+          peakAge = d.age;
+      }
+  });
+  lines.push(`資産ピーク: ${peakAge}歳 (${peakBalance.toLocaleString()}万円)`);
+
+  // Depletion or Final
+  const depletionRow = data.find(row => row.yearEndBalance < 0);
+  const finalRow = data[data.length - 1];
+
+  if (depletionRow) {
+      lines.push(`資産枯渇: ${depletionRow.age}歳でマイナスに転落`);
+  } else if (finalRow) {
+      lines.push(`最終資産(${finalRow.age}歳時点): ${finalRow.yearEndBalance.toLocaleString()}万円`);
+  }
+
+  // Retirement Point
+  const retirementRow = data.find(r => r.age === input.retirementAge);
+  if (retirementRow) {
+      lines.push(`退職時(${input.retirementAge}歳)の資産: ${retirementRow.yearEndBalance.toLocaleString()}万円`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatDuration(duration: number | 'infinite'): string {
+    return duration === 'infinite' ? '永続' : `${duration}年間`;
+}


### PR DESCRIPTION
Implemented a feature to generate and display a text summary of the simulation inputs and results. 

This includes:
1.  **Summary Generator Logic**: A new module `src/logic/summaryGenerator.ts` that formats the simulation parameters (age, income, expenses, family) and outcomes (target reached age, peak asset value, depletion age) into a readable Japanese text.
2.  **Summary Modal**: A new UI component `src/components/SummaryModal.tsx` that presents this text and allows the user to copy it to the clipboard.
3.  **Integration**: Added a "Summary" button to the Results section (next to "Save as Image") that triggers the modal.

This allows users to easily copy a text summary of their life plan simulation for sharing or record-keeping.

---
*PR created automatically by Jules for task [14509765361475720514](https://jules.google.com/task/14509765361475720514) started by @horoama*