### PR TITLE
生活費を期間ごとに変動設定できるように変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,9 @@ function App() {
     retirementAge: 65,
     retirementBonus: 1000,
     postRetirementJobs: [],
-    monthlyLivingCost: 15,
+    livingCostPlans: [
+      { cost: 15, duration: 'infinite' }
+    ],
     housingPlans: [
       { cost: 10, duration: 'infinite' }
     ],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,10 +23,10 @@ function App() {
     retirementBonus: 1000,
     postRetirementJobs: [],
     livingCostPlans: [
-      { cost: 15, duration: 'infinite' }
+      { cost: 15, endAge: 'infinite' }
     ],
     housingPlans: [
-      { cost: 10, duration: 'infinite' }
+      { cost: 10, endAge: 'infinite' }
     ],
     children: [],
     oneTimeEvents: []

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar({ input, setInput, targetAmount, setTargetAmount }: Side
         <BasicInfoSection input={input} handleChange={handleChange} targetAmount={targetAmount} setTargetAmount={setTargetAmount} />
         <IncomeSection input={input} handleChange={handleChange} />
         <PostRetirementJobSection input={input} setInput={setInput} />
-        <ExpenseSection input={input} handleChange={handleChange} />
+        <ExpenseSection input={input} setInput={setInput} />
         <HousingSection input={input} setInput={setInput} />
         <FamilySection input={input} setInput={setInput} />
         <LifeEventSection input={input} setInput={setInput} />

--- a/src/components/sidebar/ExpenseSection.tsx
+++ b/src/components/sidebar/ExpenseSection.tsx
@@ -1,17 +1,86 @@
-import type { SimulationInput } from '../../logic/simulation';
-import { NumberInput } from './InputComponents';
+import { Trash2 } from 'lucide-react';
+import type { SimulationInput, ExpensePlan } from '../../logic/simulation';
+import { NumberInput, AddButton } from './InputComponents';
 import { TOOLTIPS } from './constants';
 
 type Props = {
   input: SimulationInput;
-  handleChange: <K extends keyof SimulationInput>(field: K, value: SimulationInput[K]) => void;
+  setInput: React.Dispatch<React.SetStateAction<SimulationInput>>;
 };
 
-export function ExpenseSection({ input, handleChange }: Props) {
+export function ExpenseSection({ input, setInput }: Props) {
+  const addLivingCostPlan = () => {
+    setInput(prev => {
+      const newPlans = [...prev.livingCostPlans];
+      if (newPlans.length > 0) {
+          const lastIndex = newPlans.length - 1;
+          if (newPlans[lastIndex].duration === 'infinite') {
+              newPlans[lastIndex] = { ...newPlans[lastIndex], duration: 10 };
+          }
+      }
+      newPlans.push({ cost: 15, duration: 'infinite' });
+      return { ...prev, livingCostPlans: newPlans };
+    });
+  };
+
+  const removeLivingCostPlan = (index: number) => {
+    setInput(prev => {
+        const filteredPlans = prev.livingCostPlans.filter((_, i) => i !== index);
+        if (filteredPlans.length > 0) {
+            const lastIndex = filteredPlans.length - 1;
+            filteredPlans[lastIndex] = { ...filteredPlans[lastIndex], duration: 'infinite' };
+        }
+        return { ...prev, livingCostPlans: filteredPlans };
+    });
+  };
+
+  const updateLivingCostPlan = <K extends keyof ExpensePlan>(index: number, field: K, value: ExpensePlan[K]) => {
+    setInput(prev => {
+      const newPlans = [...prev.livingCostPlans];
+      newPlans[index] = { ...newPlans[index], [field]: value };
+      return { ...prev, livingCostPlans: newPlans };
+    });
+  };
+
   return (
     <section>
       <h3 className="font-bold text-brand mb-3 border-b border-gray-200 pb-1">基本支出</h3>
-      <NumberInput label="基本生活費 (住居・教育除く月額・万円)" value={input.monthlyLivingCost} onChange={v => handleChange('monthlyLivingCost', v)} tooltipContent={TOOLTIPS.monthlyLivingCost} />
+      <p className="text-xs text-gray-500 mb-3">生活費のプランを順に追加してください。末尾は必ず永続となります。<br/>※各期間の金額はインフレ率に応じて調整されます。</p>
+      <div className="space-y-4">
+        {input.livingCostPlans.map((plan, i) => {
+          const isLast = i === input.livingCostPlans.length - 1;
+          return (
+            <div key={i} className="bg-gray-50 p-3 rounded border border-gray-200 relative">
+              <div className="flex justify-between items-center mb-2">
+                <span className="text-sm font-medium text-gray-700">プラン {i + 1}</span>
+                {input.livingCostPlans.length > 1 && (
+                  <button onClick={() => removeLivingCostPlan(i)} className="text-gray-400 hover:text-red-500 transition-colors">
+                    <Trash2 size={16} />
+                  </button>
+                )}
+              </div>
+              <NumberInput
+                label="基本生活費 (住居・教育除く月額・万円)"
+                value={plan.cost}
+                onChange={v => updateLivingCostPlan(i, 'cost', v)}
+                className="mb-2"
+                tooltipContent={TOOLTIPS.monthlyLivingCost}
+              />
+
+              {isLast ? (
+                <div className="flex items-center gap-2 mb-2 p-2 bg-blue-50 border border-blue-100 rounded">
+                   <span className="text-sm text-brand font-bold">永続 (以降ずっと)</span>
+                </div>
+              ) : (
+                <>
+                    <NumberInput label="期間 (年)" value={plan.duration as number} onChange={v => updateLivingCostPlan(i, 'duration', v)} tooltipContent={TOOLTIPS.housingDuration} />
+                </>
+              )}
+            </div>
+          );
+        })}
+        <AddButton onClick={addLivingCostPlan} label="生活費プランを追加" />
+      </div>
     </section>
   );
 }

--- a/src/components/sidebar/HousingSection.tsx
+++ b/src/components/sidebar/HousingSection.tsx
@@ -14,11 +14,16 @@ export function HousingSection({ input, setInput }: Props) {
       const newPlans = [...prev.housingPlans];
       if (newPlans.length > 0) {
           const lastIndex = newPlans.length - 1;
-          if (newPlans[lastIndex].duration === 'infinite') {
-              newPlans[lastIndex] = { ...newPlans[lastIndex], duration: 10 };
+          const prevEndAge = newPlans.length > 1 && typeof newPlans[lastIndex - 1].endAge === 'number'
+            ? newPlans[lastIndex - 1].endAge as number
+            : prev.currentAge;
+
+          if (newPlans[lastIndex].endAge === 'infinite') {
+              const newEndAge = Math.max(prevEndAge, prev.currentAge) + 10;
+              newPlans[lastIndex] = { ...newPlans[lastIndex], endAge: newEndAge };
           }
       }
-      newPlans.push({ cost: 10, duration: 'infinite' });
+      newPlans.push({ cost: 10, endAge: 'infinite' });
       return { ...prev, housingPlans: newPlans };
     });
   };
@@ -28,7 +33,7 @@ export function HousingSection({ input, setInput }: Props) {
         const filteredPlans = prev.housingPlans.filter((_, i) => i !== index);
         if (filteredPlans.length > 0) {
             const lastIndex = filteredPlans.length - 1;
-            filteredPlans[lastIndex] = { ...filteredPlans[lastIndex], duration: 'infinite' };
+            filteredPlans[lastIndex] = { ...filteredPlans[lastIndex], endAge: 'infinite' };
         }
         return { ...prev, housingPlans: filteredPlans };
     });
@@ -49,6 +54,11 @@ export function HousingSection({ input, setInput }: Props) {
       <div className="space-y-4">
         {input.housingPlans.map((plan, i) => {
           const isLast = i === input.housingPlans.length - 1;
+
+          const minAge = i === 0
+            ? input.currentAge + 1
+            : (input.housingPlans[i - 1].endAge as number) + 1;
+
           return (
             <div key={i} className="bg-gray-50 p-3 rounded border border-gray-200 relative">
               <div className="flex justify-between items-center mb-2">
@@ -67,7 +77,15 @@ export function HousingSection({ input, setInput }: Props) {
                 </div>
               ) : (
                 <>
-                    <NumberInput label="期間 (年)" value={plan.duration as number} onChange={v => updateHousingPlan(i, 'duration', v)} tooltipContent={TOOLTIPS.housingDuration} />
+                    <NumberInput
+                        label="終了年齢 (歳まで)"
+                        value={plan.endAge as number}
+                        onChange={v => updateHousingPlan(i, 'endAge', Math.max(minAge, v))}
+                        tooltipContent={TOOLTIPS.housingDuration}
+                    />
+                    <p className="text-xs text-gray-400 text-right mt-1">
+                        ※ {minAge}歳 〜 {plan.endAge}歳
+                    </p>
                 </>
               )}
             </div>

--- a/src/logic/simulation.test.ts
+++ b/src/logic/simulation.test.ts
@@ -15,8 +15,8 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
     retirementAge: 60,
     retirementBonus: 0,
     postRetirementJobs: [],
-    livingCostPlans: [{ cost: 10, duration: 'infinite' }],
-    housingPlans: [{ cost: 5, duration: 'infinite' }],
+    livingCostPlans: [{ cost: 10, endAge: 'infinite' }],
+    housingPlans: [{ cost: 5, endAge: 'infinite' }],
     children: [],
     oneTimeEvents: []
   };
@@ -108,7 +108,7 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
         ...baseInput,
         currentAssets: 100, // Low initial
         monthlyIncome: 10,  // 120/yr
-        livingCostPlans: [{ cost: 50, duration: 'infinite' }], // 600/yr (Deficit 480/yr)
+        livingCostPlans: [{ cost: 50, endAge: 'infinite' }], // 600/yr (Deficit 480/yr)
         interestRatePct: 10.0, // High interest
         deathAge: 35
     };
@@ -135,15 +135,23 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
     }
   });
 
-  it('should switch living cost plans at correct time', () => {
+  it('should switch living cost plans at correct age', () => {
     const multiPlanInput: SimulationInput = {
       ...baseInput,
+      currentAge: 30,
       deathAge: 40,
       livingCostPlans: [
-        { cost: 10, duration: 2 }, // Age 30, 31
-        { cost: 20, duration: 'infinite' } // Age 32+
+        { cost: 10, endAge: 32 }, // Until age 32 (exclusive? or inclusive? implementation says < endAge so exclusive of end year but active UNTIL that age number is reached?)
+        // Wait, logic is: if age < endAge.
+        // If endAge is 32.
+        // Age 30 < 32 -> Plan 1
+        // Age 31 < 32 -> Plan 1
+        // Age 32 < 32 -> False -> Next Plan
+        // So endAge is "Up to but not including the year you turn X"? Or "Until X years old"?
+        // The UI usually implies "Until age X" means "At age X-1 it applies, at age X it switches".
+        { cost: 20, endAge: 'infinite' }
       ],
-      inflationRatePct: 0.0 // Keep 0 to verify base switching logic first
+      inflationRatePct: 0.0
     };
     const result = calculateSimulation(multiPlanInput);
 
@@ -151,7 +159,7 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
     expect(result[0].expenseBreakdown.living).toBe(10 * 12);
     // Age 31 (Year 1)
     expect(result[1].expenseBreakdown.living).toBe(10 * 12);
-    // Age 32 (Year 2)
+    // Age 32 (Year 2) -> Should switch
     expect(result[2].expenseBreakdown.living).toBe(20 * 12);
     // Age 33 (Year 3)
     expect(result[3].expenseBreakdown.living).toBe(20 * 12);
@@ -160,10 +168,11 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
   it('should apply inflation to switched living cost plans', () => {
     const multiPlanInput: SimulationInput = {
       ...baseInput,
+      currentAge: 30,
       deathAge: 40,
       livingCostPlans: [
-        { cost: 10, duration: 2 }, // Age 30, 31
-        { cost: 20, duration: 'infinite' } // Age 32+
+        { cost: 10, endAge: 32 },
+        { cost: 20, endAge: 'infinite' }
       ],
       inflationRatePct: 10.0 // 10% easy math
     };

--- a/src/logic/simulation.ts
+++ b/src/logic/simulation.ts
@@ -1,11 +1,11 @@
 export type HousingPlan = {
   cost: number;
-  duration: number | 'infinite';
+  endAge: number | 'infinite';
 };
 
 export type ExpensePlan = {
   cost: number;
-  duration: number | 'infinite';
+  endAge: number | 'infinite';
 };
 
 export type PostRetirementJob = {
@@ -202,23 +202,20 @@ export function calculateSimulation(input: SimulationInput): SimulationYearResul
     // 1. Basic Living Cost (Inflated)
     // nominal = base * inflationFactor
     let currentLivingCostBase = 0;
-    let livingCumulativeYears = 0;
     let livingPlanFound = false;
 
     for (const plan of livingCostPlans) {
-      const { duration, cost } = plan;
-      if (duration === 'infinite') {
+      const { endAge: planEndAge, cost } = plan;
+      if (planEndAge === 'infinite') {
         currentLivingCostBase = cost;
         livingPlanFound = true;
         break;
       }
-      const dur = duration as number;
-      if (yearsPassed < livingCumulativeYears + dur) {
+      if (age < planEndAge) {
         currentLivingCostBase = cost;
         livingPlanFound = true;
         break;
       }
-      livingCumulativeYears += dur;
     }
     if (!livingPlanFound && livingCostPlans.length > 0) {
         currentLivingCostBase = livingCostPlans[livingCostPlans.length - 1].cost;
@@ -228,23 +225,20 @@ export function calculateSimulation(input: SimulationInput): SimulationYearResul
 
     // 2. Housing Cost (NOT Inflated - Fixed Nominal)
     let currentHousingCostBase = 0;
-    let cumulativeYears = 0;
     let planFound = false;
 
     for (const plan of housingPlans) {
-      const { duration, cost } = plan;
-      if (duration === 'infinite') {
+      const { endAge: planEndAge, cost } = plan;
+      if (planEndAge === 'infinite') {
         currentHousingCostBase = cost;
         planFound = true;
         break;
       }
-      const dur = duration as number;
-      if (yearsPassed < cumulativeYears + dur) {
+      if (age < planEndAge) {
         currentHousingCostBase = cost;
         planFound = true;
         break;
       }
-      cumulativeYears += dur;
     }
     if (!planFound && housingPlans.length > 0) {
         currentHousingCostBase = housingPlans[housingPlans.length - 1].cost;


### PR DESCRIPTION
生活費を住宅費と同様に、期間ごとに異なる金額を設定できるように実装しました。
また、各期間の生活費はインフレ率に応じて調整される仕様としています。

変更点:
- `src/logic/simulation.ts`: `monthlyLivingCost` (number) を `livingCostPlans` (ExpensePlan[]) に変更。シミュレーション計算ロジックを更新。
- `src/App.tsx`: 初期状態の更新。
- `src/components/sidebar/ExpenseSection.tsx`: UIをリスト形式に変更。
- `src/logic/simulation.test.ts`: テストケースの修正と追加。

---
*PR created automatically by Jules for task [15118604267919330091](https://jules.google.com/task/15118604267919330091) started by @horoama*