### PR TITLE
共有リンクから開いた際のグラフパネルのレイアウト崩れを修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,7 @@ function App() {
       </div>
 
       {/* Results (Graph) */}
-      <div className={`flex-1 ${activeTab === 'result' ? 'block' : 'hidden lg:block'}`}>
+      <div className={`flex-1 min-w-0 ${activeTab === 'result' ? 'block' : 'hidden lg:block'}`}>
         <Results
           data={simulationData}
           targetAmount={targetAmount}

--- a/verification/verify_layout.py
+++ b/verification/verify_layout.py
@@ -1,0 +1,55 @@
+import os
+from playwright.sync_api import sync_playwright, expect
+
+def verify_layout(page):
+    # Setup local storage to skip welcome modal
+    page.goto("http://localhost:5173/")
+    page.evaluate("localStorage.setItem('hasVisited', 'true')")
+    page.reload()
+
+    # Wait for sidebar title
+    # Desktop uses h2, Mobile uses h1. Since we are 1280px, h2 should be visible.
+    page.wait_for_selector("h2:has-text('人生見えるくん')")
+
+    # Scroll to "イベントを追加" button and click it
+    add_btn = page.get_by_role("button", name="イベントを追加")
+
+    # Ensure button is ready
+    add_btn.scroll_into_view_if_needed()
+    add_btn.click()
+
+    # Find the input for event name. It has value "旅行" by default.
+    event_input = page.locator('input[value="旅行"]')
+    event_input.fill("あ" * 100) # Very long string
+
+    # Wait a bit for React to update state and recalc results
+    page.wait_for_timeout(2000)
+
+    # Check for horizontal scroll on the body/html
+    dimensions = page.evaluate("""() => {
+        return {
+            scrollWidth: document.documentElement.scrollWidth,
+            innerWidth: window.innerWidth,
+            bodyScrollWidth: document.body.scrollWidth
+        }
+    }""")
+
+    print(f"Dimensions: {dimensions}")
+
+    # Take screenshot
+    page.screenshot(path="verification/layout_issue.png", full_page=True)
+
+    if dimensions['scrollWidth'] > dimensions['innerWidth']:
+        print("FAIL: Horizontal scroll detected on page.")
+    else:
+        print("PASS: No horizontal scroll detected.")
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1280, "height": 720})
+        page = context.new_page()
+        try:
+            verify_layout(page)
+        finally:
+            browser.close()


### PR DESCRIPTION
## 概要
共有リンクから開いた際や、長い文字列を入力した際に、結果画面のグラフパネルが横に広がり、画面全体に横スクロールが発生する問題を修正しました。

## 原因
Flexboxの子要素である `Results` コンポーネントのラッパーにおいて、`min-width` の指定がデフォルトの `auto` になっていたため、内部のテーブルなどのコンテンツ幅がコンテナ幅を超えた場合に、親要素を押し広げていました。

## 修正内容
`src/App.tsx` の `Results` コンポーネントのラッパー `div` に `min-w-0` クラスを追加しました。これにより、コンテンツ幅に関わらずコンテナの幅（`flex-1`）に収まるようになり、内部のスクロールが正しく機能するようになります。

## 検証
Playwrightによる自動テストを行い、長いイベント名を入力しても画面全体の横スクロールが発生しないことを確認しました。
また、既存のテストスイートもパスしています。

---
*PR created automatically by Jules for task [15281298795487137242](https://jules.google.com/task/15281298795487137242) started by @horoama*