### PR TITLE
要約テキストの生成ロジックを更新し、FIRE向けの表現に変更

### DIFF
--- a/src/logic/summaryGenerator.test.ts
+++ b/src/logic/summaryGenerator.test.ts
@@ -115,7 +115,7 @@ describe('generateSimulationSummary', () => {
     expect(summary).toContain('資産運用益: 450万円');
 
     // Check Working Phase
-    expect(summary).toContain('■ 現役期間 (〜64歳)');
+    expect(summary).toContain('■ 前半期間 (〜64歳)');
     // Working rows: age 30, 40, 50
     // Income: 460 + 500 + 550 = 1510
     // Inv Income: 0 + 50 + 100 = 150
@@ -123,7 +123,7 @@ describe('generateSimulationSummary', () => {
     expect(summary).toContain('収入合計: 1,660万円');
 
     // Check Retired Phase
-    expect(summary).toContain('■ 老後期間 (65歳〜)');
+    expect(summary).toContain('■ 後半期間 (65歳〜)');
     // Retired rows: 65, 80, 90
     // Income: 1500 + 200 + 200 = 1900
     // Inv Income: 200 + 100 + 0 = 300
@@ -155,5 +155,32 @@ describe('generateSimulationSummary', () => {
      expect(summary).toContain('住居費:');
      expect(summary).toContain('月10万円 (40歳まで)');
      expect(summary).toContain('月5万円 (永続)');
+  });
+
+  it('should list all jobs chronologically and avoid "retirement age" wording', () => {
+    const jobInput: SimulationInput = {
+      ...baseInput,
+      retirementAge: 60,
+      postRetirementJobs: [
+        { startAge: 60, endAge: 65, monthlyIncome: 20, retirementBonus: 50 },
+        { startAge: 65, endAge: 'infinite', monthlyIncome: 10, retirementBonus: 0 }
+      ]
+    };
+    const summary = generateSimulationSummary(jobInput, mockData, 3000);
+
+    expect(summary).toContain('■ 収入・働き方');
+    expect(summary).not.toContain('定年退職'); // Should not use "Teinen"
+
+    // Main Job
+    expect(summary).toContain('メインの仕事 (30歳〜60歳):');
+    expect(summary).toContain('月収30万円');
+
+    // Post Retirement Jobs
+    expect(summary).toContain('その他の仕事1 (60歳〜65歳):');
+    expect(summary).toContain('月収20万円');
+    expect(summary).toContain('退職一時金: 50万円');
+
+    expect(summary).toContain('その他の仕事2 (65歳〜永続):');
+    expect(summary).toContain('月収10万円');
   });
 });

--- a/src/logic/summaryGenerator.ts
+++ b/src/logic/summaryGenerator.ts
@@ -14,15 +14,26 @@ export function generateSimulationSummary(
   lines.push(`現在の資産: ${input.currentAssets.toLocaleString()}万円`);
 
   lines.push('');
-  lines.push('■ 収入・資産運用');
-  lines.push(`メインの就労収入: 月収${input.monthlyIncome.toLocaleString()}万円 / ボーナス年${input.annualBonus.toLocaleString()}万円`);
+  lines.push('■ 収入・働き方');
+
+  lines.push(`メインの仕事 (${input.currentAge}歳〜${input.retirementAge}歳):`);
+  lines.push(`  - 月収${input.monthlyIncome.toLocaleString()}万円 / ボーナス年${input.annualBonus.toLocaleString()}万円`);
   if (input.incomeIncreaseRatePct > 0) {
-    lines.push(`収入上昇率: 年${input.incomeIncreaseRatePct}%`);
+    lines.push(`  - 収入上昇率: 年${input.incomeIncreaseRatePct}%`);
   }
-  lines.push(`定年退職: ${input.retirementAge}歳 (退職金 ${input.retirementBonus.toLocaleString()}万円)`);
-  if (input.postRetirementJobs.length > 0) {
-    lines.push('退職後の働き方: あり');
+  if (input.retirementBonus > 0) {
+    lines.push(`  - 退職金: ${input.retirementBonus.toLocaleString()}万円`);
   }
+
+  input.postRetirementJobs.forEach((job, idx) => {
+    const endStr = job.endAge === 'infinite' ? '永続' : `${job.endAge}歳`;
+    lines.push(`その他の仕事${idx + 1} (${job.startAge}歳〜${endStr}):`);
+    lines.push(`  - 月収${job.monthlyIncome.toLocaleString()}万円`);
+    if (job.retirementBonus > 0) {
+      lines.push(`  - 退職一時金: ${job.retirementBonus.toLocaleString()}万円`);
+    }
+  });
+
   lines.push(`想定利回り: 年${input.interestRatePct}%`);
 
   lines.push('');
@@ -199,7 +210,7 @@ export function generateSimulationSummary(
   lines.push('--------------------');
 
   // Output: Working Phase
-  lines.push(`■ 現役期間 (〜${input.retirementAge - 1}歳)`);
+  lines.push(`■ 前半期間 (〜${input.retirementAge - 1}歳)`);
   lines.push(`収入合計: ${fmt(working.income.total)}`);
   lines.push(`支出合計: ${fmt(working.expense.total)}`);
   const workNet = working.income.total.nominal - working.expense.total.nominal;
@@ -209,7 +220,7 @@ export function generateSimulationSummary(
   lines.push('');
 
   // Output: Retired Phase
-  lines.push(`■ 老後期間 (${input.retirementAge}歳〜)`);
+  lines.push(`■ 後半期間 (${input.retirementAge}歳〜)`);
   lines.push(`収入合計: ${fmt(retired.income.total)}`);
   lines.push(`支出合計: ${fmt(retired.expense.total)}`);
   const retNet = retired.income.total.nominal - retired.expense.total.nominal;


### PR DESCRIPTION
シミュレーション要約（SummaryGenerator）において、「定年退職」という言葉を削除し、事実ベースの「仕事期間」として記述するように変更しました。また、メインの仕事と複数の定年後の仕事を時系列で漏れなくリストアップするように改善しました。収支詳細のヘッダーも「現役期間/老後期間」から「前半期間/後半期間」へ変更し、早期リタイア（FIRE）のシナリオでも違和感のない表現にしました。

---
*PR created automatically by Jules for task [17151888740775098200](https://jules.google.com/task/17151888740775098200) started by @horoama*