### PR TITLE
Round simulation values to one decimal place

### DIFF
--- a/src/logic/simulation.test.ts
+++ b/src/logic/simulation.test.ts
@@ -50,8 +50,9 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
 
     // Year 5
     // Nominal Living = 10 * 12 * 1.02^5
-    // 10 * 12 * 1.10408 = 132.49
-    expect(result[5].expenseBreakdown.living).toBeCloseTo(120 * Math.pow(1.02, 5), 4);
+    // 10 * 12 * 1.10408 = 132.49 -> Rounded to 132.5
+    const expected = Math.round(120 * Math.pow(1.02, 5) * 10) / 10;
+    expect(result[5].expenseBreakdown.living).toBe(expected);
     expect(result[5].expenseBreakdown.living).toBeGreaterThan(120);
   });
 
@@ -64,7 +65,9 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
     // Real Assets should be Nominal / 1.02^5
     const nominal = result[5].yearEndBalance;
     const real = result[5].yearEndBalanceReal;
-    const expectedReal = Math.floor(nominal / Math.pow(1.02, 5));
+
+    // Now using rounding instead of floor
+    const expectedReal = Math.round((nominal / Math.pow(1.02, 5)) * 10) / 10;
 
     expect(real).toBe(expectedReal);
     expect(real).toBeLessThan(nominal);
@@ -80,7 +83,8 @@ describe('calculateSimulation with Inflation and Growth (Nominal Output)', () =>
 
     // Year 5
     // Nominal Income = 360 * 1.03^5
-    expect(result[5].annualIncome).toBeCloseTo(360 * Math.pow(1.03, 5), 4);
+    const expected = Math.round(360 * Math.pow(1.03, 5) * 10) / 10;
+    expect(result[5].annualIncome).toBe(expected);
   });
 
   it('should NOT apply income growth to retirement bonus (Nominal)', () => {

--- a/src/logic/simulation.ts
+++ b/src/logic/simulation.ts
@@ -106,6 +106,10 @@ export const EDU_COSTS_MAP = {
   }
 };
 
+function roundVal(val: number): number {
+  return Math.round(val * 10) / 10;
+}
+
 export function calculateSimulation(input: SimulationInput): SimulationYearResult[] {
   const {
     currentAge,
@@ -306,26 +310,26 @@ export function calculateSimulation(input: SimulationInput): SimulationYearResul
       age,
       yearsPassed,
       event: eventNotes.join(', '),
-      monthlyHousingCost: currentHousingCostNominal, // Nominal (Face Value)
-      annualIncome: annualIncomeNominal, // Nominal
-      annualExpenses: annualExpensesNominal, // Nominal
-      annualSavings: netSavingsNominal, // Nominal
-      yearEndBalance: Math.floor(assets), // Nominal
-      yearEndBalanceReal: Math.floor(assets / inflationFactor), // Real (Reference)
-      investmentIncome: Math.floor(investmentIncomeNominal), // Nominal
-      totalPrincipal: Math.floor(totalPrincipal), // Nominal
-      totalInvestmentIncome: Math.floor(totalInvestmentIncome), // Nominal
+      monthlyHousingCost: roundVal(currentHousingCostNominal), // Nominal (Face Value)
+      annualIncome: roundVal(annualIncomeNominal), // Nominal
+      annualExpenses: roundVal(annualExpensesNominal), // Nominal
+      annualSavings: roundVal(netSavingsNominal), // Nominal
+      yearEndBalance: roundVal(assets), // Nominal
+      yearEndBalanceReal: roundVal(assets / inflationFactor), // Real (Reference)
+      investmentIncome: roundVal(investmentIncomeNominal), // Nominal
+      totalPrincipal: roundVal(totalPrincipal), // Nominal
+      totalInvestmentIncome: roundVal(totalInvestmentIncome), // Nominal
       incomeBreakdown: {
-        salary: mainJobIncome, // Nominal
-        bonus: mainJobBonus, // Nominal
-        pension: postRetirementIncome, // Nominal
-        oneTime: oneTimeIncome // Nominal
+        salary: roundVal(mainJobIncome), // Nominal
+        bonus: roundVal(mainJobBonus), // Nominal
+        pension: roundVal(postRetirementIncome), // Nominal
+        oneTime: roundVal(oneTimeIncome) // Nominal
       },
       expenseBreakdown: {
-        living: basicLivingExpense, // Nominal
-        housing: housingExpense, // Nominal
-        education: childExpense, // Nominal
-        oneTime: oneTimeExpense // Nominal
+        living: roundVal(basicLivingExpense), // Nominal
+        housing: roundVal(housingExpense), // Nominal
+        education: roundVal(childExpense), // Nominal
+        oneTime: roundVal(oneTimeExpense) // Nominal
       }
     });
 


### PR DESCRIPTION
Changes the simulation logic to round all monetary values (assets, income, expenses) to the first decimal place (e.g., 123.4) instead of flooring them to integers. This enhances precision and readability in the results table and charts.

- Modified `src/logic/simulation.ts` to use a new `roundVal` helper.
- Updated `src/logic/simulation.test.ts` to align with the new rounding logic.
- Verified that frontend tables display values with max 1 decimal place.

---
*PR created automatically by Jules for task [10886215412239822247](https://jules.google.com/task/10886215412239822247) started by @horoama*